### PR TITLE
Changed to DC

### DIFF
--- a/app/views/index.erb
+++ b/app/views/index.erb
@@ -23,7 +23,7 @@
   <div class="main pure-u-3-4">
 
     <p class="me">
-      <strong>Eric Mill</strong> is a leader and technology expert in Washington, D.C., making better public services and smarter policy.
+      <strong>Eric Mill</strong> is a leader and technology expert in Washington, DC, making better public services and smarter policy.
     </p>
 
     <p>


### PR DESCRIPTION
I dislike the use of `D.C.` and instead prefer `DC`. If you need authority, rely on the [18F Content Guide](https://content-guide.18f.gov/specific-words-and-phrases/).